### PR TITLE
revise compiled module name to dm-jindisk

### DIFF
--- a/kernel-module/c/Makefile
+++ b/kernel-module/c/Makefile
@@ -4,12 +4,12 @@ ifeq (${DEBUG}, 1)
 	ccflags-y	+= -g -DDEBUG
 endif
 
-jindisk-objs		+= src/dm-jindisk.o src/metadata.o src/memtable.o      \
+dm-jindisk-objs		+= src/dm-jindisk.o src/metadata.o src/memtable.o      \
 			   src/lsm_tree.o src/crypto.o src/segment_buffer.o    \
 			   src/segment_allocator.o src/journal.o src/cache.o   \
 			   src/disk_structs.o src/async.o
 
-obj-m			+= jindisk.o
+obj-m			+= dm-jindisk.o
 
 all:
 	make -C ${KER_SRC} M=$(PWD) modules

--- a/kernel-module/c/mount-img.sh
+++ b/kernel-module/c/mount-img.sh
@@ -5,6 +5,6 @@ dd if=/dev/null of=./disk.img seek=25165824 # data: 10G meta: 2G
 losetup /dev/loop0 ./disk.img
 
 modprobe dm_bufio
-insmod jindisk.ko
+insmod dm-jindisk.ko
 
 echo 0 20971520 jindisk a7f67ad520bd83b971225df6ebd76c3e c01be00ba5f730aacb039e86 /dev/loop0 1 | dmsetup create test-jindisk

--- a/kernel-module/c/remove-img.sh
+++ b/kernel-module/c/remove-img.sh
@@ -2,7 +2,7 @@
 
 dmsetup remove test-jindisk
 
-rmmod jindisk.ko
+rmmod dm-jindisk.ko
 modprobe -r dm_bufio
 
 losetup -d /dev/loop0


### PR DESCRIPTION
We can keep the struct `target_type` name as jindisk (just like the dm-crypt), and only rename compile target to dm-jindisk.
```bash
# modprobe dm-bufio
# insmod dm-jindisk.ko
# lsmod | grep dm_jindisk
dm_jindisk            114688  1
dm_bufio               32768  1 dm_jindisk
```
#16 